### PR TITLE
Adding support for .h and .hpp files

### DIFF
--- a/utils/comments.go
+++ b/utils/comments.go
@@ -6,6 +6,7 @@ const commonPostfix = "*/"
 // SupportedComments is mapping of language extension with syntax
 var SupportedComments = map[string]([2]string){
 	"h":      [2]string{commonPrefix, commonPostfix},
+	"hpp":    [2]string{commonPrefix, commonPostfix},
 	"html":   [2]string{"<!-- ", "-->"},
 	"js":     [2]string{commonPrefix, commonPostfix},
 	"jsx":    [2]string{commonPrefix, commonPostfix},

--- a/utils/comments.go
+++ b/utils/comments.go
@@ -5,6 +5,7 @@ const commonPostfix = "*/"
 
 // SupportedComments is mapping of language extension with syntax
 var SupportedComments = map[string]([2]string){
+	"h":      [2]string{commonPrefix, commonPostfix},
 	"html":   [2]string{"<!-- ", "-->"},
 	"js":     [2]string{commonPrefix, commonPostfix},
 	"jsx":    [2]string{commonPrefix, commonPostfix},


### PR DESCRIPTION
h and hpp files use the same format as C files with `/*' as the start and '*/' as the end

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/marvin9/licensor/1)
<!-- Reviewable:end -->
